### PR TITLE
Add Skills宝 to Meta Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ A curated collection of **1000** Claude Skills for [Claude Code](https://claude.
 | [Skill Development](https://www.skillhub.club/skill/anthropics-claude-code-skill-development) | anthropics | ⭐ 94.4k | A comprehensive meta-skill providing clear guideli... |
 | [skill-creator](https://www.skillhub.club/skill/openai-codex-skill-creator) | openai | ⭐ 70.6k | Provides guidance and templates for creating Claud... |
 | [skill-creator](https://www.skillhub.club/skill/tldraw-tldraw-skill-creator) | tldraw | ⭐ 46.1k | A meta-skill that provides structured guidance and... |
+| [skillsbao-registry](https://www.skillhub.club/skill/skillsbao-registry) | Skills宝 | ⭐ - | Chinese search and installation registry for Claude Code, OpenCode, Cursor, and other agent skills |
 | [hive-mind-advanced](https://www.skillhub.club/skill/ruvnet-claude-code-flow-hive-mind-advanced) | ruvnet | ⭐ 29.0k | This skill implements a queen-worker multi-agent s... |
 | [skill-builder](https://www.skillhub.club/skill/ruvnet-claude-code-flow-skill-builder) | ruvnet | ⭐ 29.0k | This skill provides detailed guidance for creating... |
 


### PR DESCRIPTION
Adds Skills宝 as a meta skill resource for discovering and installing Claude Code, OpenCode, Cursor, and other agent skills.

This keeps the README aligned with the repository's curated skill catalog and adds a Chinese discovery option for users who want a centralized registry.